### PR TITLE
Abstract async saving

### DIFF
--- a/tests/v1/kv_connector/unit/test_remote_decode_lifecycle.py
+++ b/tests/v1/kv_connector/unit/test_remote_decode_lifecycle.py
@@ -20,6 +20,7 @@ def test_basic_lifecycle():
     NUM_TOKENS = int(BLOCK_SIZE * (NUM_EXTERNAL_FULL_BLOCKS + 0.5))
 
     request = create_request(request_id=1,
+                             max_tokens=1,
                              num_tokens=NUM_TOKENS,
                              do_remote_decode=True)
 
@@ -41,9 +42,9 @@ def test_basic_lifecycle():
 
     # Ensure the request is finished after 1 tokens.
     assert request.is_finished()
-    assert request.status == RequestStatus.FINISHED_REMOTE_DECODE
+    assert request.status == RequestStatus.FINISHED_LENGTH_CAPPED
     output = engine_core_outputs.outputs[0]
-    assert output.finish_reason == FinishReason.REMOTE_DECODE
+    assert output.finish_reason == FinishReason.LENGTH
     assert output.kv_transfer_params is not None
 
     # Request freed in Scheduler and in Persistent Batch ...
@@ -101,6 +102,7 @@ def test_short_prompt_lifecycle():
     # Not enough tokens for full block.
     NUM_TOKENS = vllm_config.cache_config.block_size // 2
     request = create_request(request_id=1,
+                             max_tokens=1,
                              num_tokens=NUM_TOKENS,
                              do_remote_decode=True)
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Optional
 import torch
 
 from vllm.logger import init_logger
+from vllm.sampling_params import KVTransferParams
 from vllm.v1.core.sched.output import SchedulerOutput
 
 if TYPE_CHECKING:
@@ -198,7 +199,7 @@ class KVConnectorBase_V1(ABC):
         Returns:
             the number of tokens that can be loaded from the 
             external KV cache beyond what is already computed.
-            true if the external KV cache tokens will be loaded
+            True if the external KV cache tokens will be loaded
             asynchronously (between scheduler steps).
         """
         pass
@@ -225,3 +226,22 @@ class KVConnectorBase_V1(ABC):
             scheduler_output (SchedulerOutput): the scheduler output object.
         """
         pass
+
+    # TODO: KVTransferParams is currently specific to NixlConnector,
+    #  make it generic
+    def request_finished(
+        self,
+        request: "Request",
+        blocks: "KVCacheBlocks",
+    ) -> tuple[bool, Optional[KVTransferParams]]:
+        """
+        Called when a request has finished, before its blocks are freed.
+
+        Returns:
+            True if the request is being saved/sent asynchronously and blocks
+            should not be freed until the request_id is returned from
+            get_finished().
+            Optional KVTransferParams to be included in the request outputs
+            returned by the engine.
+        """
+        return False, None

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -428,8 +428,7 @@ class KVCacheManager:
         Returns:
             int: The number of common prefix blocks.
         """
-        assert request.status in (RequestStatus.RUNNING,
-                                  RequestStatus.FINISHED_REMOTE_DECODE)
+        assert request.status == RequestStatus.RUNNING
         blocks = self.req_to_blocks[request.request_id]
         num_common_blocks = 0
         for block in blocks:

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -16,7 +16,7 @@ from vllm.v1.outputs import LogprobsLists, LogprobsTensors
 
 # These are possible values of RequestOutput.finish_reason,
 # so form part of the external API.
-FINISH_REASON_STRINGS = ("stop", "length", "abort", "remote_decode")
+FINISH_REASON_STRINGS = ("stop", "length", "abort")
 
 
 class FinishReason(enum.IntEnum):
@@ -28,13 +28,11 @@ class FinishReason(enum.IntEnum):
     stop - a stop string was emitted
     length - max_tokens was consumed, or max_model_len was reached
     abort - aborted for another reason
-    remote_decode - request will be processed as a remote_decode 
 
     """
     STOP = 0
     LENGTH = 1
     ABORT = 2
-    REMOTE_DECODE = 3
 
     def __str__(self):
         return FINISH_REASON_STRINGS[self.value]

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -168,7 +168,6 @@ class RequestStatus(enum.IntEnum):
     FINISHED_LENGTH_CAPPED = enum.auto()
     FINISHED_ABORTED = enum.auto()
     FINISHED_IGNORED = enum.auto()
-    FINISHED_REMOTE_DECODE = enum.auto()
 
     @staticmethod
     def is_finished(status: "RequestStatus") -> bool:
@@ -189,5 +188,4 @@ _FINISHED_REASON_MAP = {
     RequestStatus.FINISHED_LENGTH_CAPPED: FinishReason.LENGTH,
     RequestStatus.FINISHED_ABORTED: FinishReason.ABORT,
     RequestStatus.FINISHED_IGNORED: FinishReason.LENGTH,
-    RequestStatus.FINISHED_REMOTE_DECODE: FinishReason.REMOTE_DECODE
 }


### PR DESCRIPTION
Generalize async saving/sending. Add a new request_finished method to the scheduler side of the connector interface and move the nixl-specific logic there. This means it could be used for async kvcache offload in lmcache for example.

Remove the separate `FINISHED_REMOTE_DECODE` state. I think the only difference here for the nixl use case is that the proxy/sidecar will need to send `max_tokens=1` in the initial prefill request.